### PR TITLE
Updated energy dissipation calculation

### DIFF
--- a/kolmogorov_demo.ipynb
+++ b/kolmogorov_demo.ipynb
@@ -258,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -306,7 +306,7 @@
     "\n",
     "# Compute energy dissipation for each timestep\n",
     "for omega_hat in trajectory[:]:\n",
-    "    total_epsilon = utils.compute_energy_dissipation(omega_hat, kx, ky, flow.nu, n)    \n",
+    "    total_epsilon = utils.compute_energy_dissipation(omega_hat, flow.nu)    \n",
     "    dissipation.append(total_epsilon)\n",
     "        \n",
     "plt.plot(dissipation)\n",

--- a/ml/datagen.py
+++ b/ml/datagen.py
@@ -29,7 +29,7 @@ def get_extreme_event_times(trajectory):
     # Compute energy dissipation for each timestep
     dissipation = []
     for omega_hat in trajectory:
-        total_epsilon = utils.compute_energy_dissipation(omega_hat, kx, ky, flow.nu, n)    
+        total_epsilon = utils.compute_energy_dissipation(omega_hat, flow.nu)    
         dissipation.append(total_epsilon)
     mean_diss = jnp.mean(np.array(dissipation))
     event_times = []

--- a/ml/ddpg.py
+++ b/ml/ddpg.py
@@ -82,7 +82,7 @@ class KolmogorovFlow(gym.Env):
         return np.array([observation]), reward, done, {}
     
     def compute_measurement(self, state):
-        return utils.compute_energy_dissipation(state, kx, ky, flow.nu, 256)
+        return utils.compute_energy_dissipation(state, flow.nu)
     
     def compute_energy(self, state):
         uhat, vhat = utils.compute_velocity_fft(state, kx, ky)


### PR DESCRIPTION
Simplified the energy dissipation calculation for incompressible flows with periodic boundary conditions so that it only relies on the vorticity squared: 

$$
\varepsilon = \frac{\nu}{|\Omega|} \int_\Omega |\omega(x,y)|^2 dxdy
$$

- Implementation does not need access to the meshes, nor resolution, so those have been taken out of the constructor.
- Changed the other references to the function.

